### PR TITLE
feat: add provider-specific instructions to remoteRef

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -174,6 +174,19 @@ spec:
         version: provider-key-version
         property: provider-key-property
 
+        # (optional) provider-specific instructions on how to fetch the secret
+        azurekv:
+          # fetch tags and use ref.property to extract a certain tag
+          # tags are included in a GetSecret() respose
+          # see https://github.com/Azure/azure-sdk-for-go/blob/v51.1.0/services/keyvault/v7.0/keyvault/models.go#L2865
+          fetchTags: true
+        awssm:
+          # causes a DescribeSecret() request to fetch the assigned tags
+          # https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#DescribeSecretOutput
+          fetchTags: true
+          # If the backend secret shall be treated as binary data represented by a base64-encoded string
+          binary: true
+
   # Used to fetch all properties from the Provider key
   # If multiple dataFrom are specified, secrets are merged in the specified order
   dataFrom:

--- a/Spec.md
+++ b/Spec.md
@@ -174,18 +174,12 @@ spec:
         version: provider-key-version
         property: provider-key-property
 
-        # (optional) provider-specific instructions on how to fetch the secret
-        azurekv:
-          # fetch tags and use ref.property to extract a certain tag
-          # tags are included in a GetSecret() respose
-          # see https://github.com/Azure/azure-sdk-for-go/blob/v51.1.0/services/keyvault/v7.0/keyvault/models.go#L2865
-          fetchTags: true
-        awssm:
-          # causes a DescribeSecret() request to fetch the assigned tags
-          # https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#DescribeSecretOutput
-          fetchTags: true
-          # If the backend secret shall be treated as binary data represented by a base64-encoded string
-          binary: true
+        # Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+        metadataPolicy: Fetch
+
+        # Strategy for decoding provider secrets, options are Binary, Base64, BestEffort. Defaults to BestEffort
+        # BestEffort tries to use an content-type indicator from the upstream API if provided.
+        decodeStrategy: Binary
 
   # Used to fetch all properties from the Provider key
   # If multiple dataFrom are specified, secrets are merged in the specified order


### PR DESCRIPTION
As discussed in https://github.com/external-secrets/external-secrets/pull/22#discussion_r571436199

Problem:
(1) A user can't fetch the tags of a secret.
(2) I found another use-case that requires provider-specific options ([KES base64/isBinary](https://github.com/external-secrets/kubernetes-external-secrets/blob/master/lib/backends/kv-backend.js#L72-L80))

I see two options:

(A) Template Galore :horse_racing: 

Tl;DR: use template functions to access metadata or transform base64/pkcs12/pem...

(I think this is a low-hangig fruit once we have basic templating anyway)
```yaml
spec:
  secretStoreRef:
    name: my-az-store
  data:
  - secretKey: user
     remoteRef:
       key: my-key
  - secretKey: cert
     remoteRef:
       key: my-cert
  target:
    template:
      data:
        # .data.user is the actual secret .Value from azkv 
        # .metadata.user is metadata from azure (e.g. version, Tags, content-type)
        example.yml: |
          endpoints:
          - url: https://{{ .data.user }}:{{ .data.password }}@api.exmaple.com
             headers:
               UserAgent: {{.metadata.user.tags.USER_AGENT }}
        # different option to transform the secret value pkcs12 -> []PEM -> cert
        # this is just an idea
        mycert: '{{ .data.cert. | extractPKCS12 | filterPEMCert }}'
```

(B) provider-specific options in the remoteRef
See proposed changes.
